### PR TITLE
API 예외처리 #17

### DIFF
--- a/server/src/main/java/com/codestates/preproject/advice/GlobalExceptionAdvice.java
+++ b/server/src/main/java/com/codestates/preproject/advice/GlobalExceptionAdvice.java
@@ -1,0 +1,86 @@
+package com.codestates.preproject.advice;
+
+import com.codestates.preproject.exception.BusinessLogicException;
+import com.codestates.preproject.exception.ExceptionCode;
+import com.codestates.preproject.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import javax.validation.ConstraintViolationException;
+import java.nio.file.AccessDeniedException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionAdvice {
+    // Method Argument Not Valid Error : Controller/Service @Valid @Validated 유효성 검증 실패 오류, 예외 처리
+    @ExceptionHandler @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException", e);
+        final ErrorResponse errorResponse = ErrorResponse.of(e.getBindingResult());
+        return errorResponse;
+    }
+
+    // ConstraintViolation Error : JPA @Valid @Validated 유효성 검증에 실패 오류, 예외 처리
+    @ExceptionHandler @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleConstraintViolationException(ConstraintViolationException e) {
+        log.error("ConstraintViolationException", e);
+        final ErrorResponse errorResponse = ErrorResponse.of(e.getConstraintViolations());
+        return errorResponse;
+    }
+
+    // Bind Error : @Valid, @Validated 에서 binding error 발생 시
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.error("handleBindException", e);
+        final ErrorResponse errorResponse = ErrorResponse.of(ExceptionCode.INVALID_INPUT_VALUE);
+        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(ExceptionCode.INVALID_INPUT_VALUE.getStatus()));
+    }
+
+    // MethodArgumentTypeMismatch Error : Method 매개변수 타입 불일치 오류, 예외처리
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException", e);
+        final ErrorResponse errorResponse = ErrorResponse.of(ExceptionCode.INVALID_INPUT_VALUE);
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    // HttpRequestMethodNotSupported Error : 지원하지 않는 HTTP Request 오류, 예외처리
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        final ErrorResponse errorResponse = ErrorResponse.of(ExceptionCode.METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(errorResponse, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    // AccessDenied Error : 인가 거부 오류, 예외 처리
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("handleAccessDeniedException", e);
+        final ErrorResponse errorResponse = ErrorResponse.of(ExceptionCode.HANDLE_ACCESS_DENIED);
+        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(ExceptionCode.HANDLE_ACCESS_DENIED.getStatus()));
+    }
+
+    // BusienessLogic Error : BusinessLogicException 에 등록 된 오류, 예외 처리
+    @ExceptionHandler(BusinessLogicException.class)
+    public ResponseEntity handleBusinessLogicException(BusinessLogicException e) {
+        log.error("handleBusinessLogicException", e);
+        final ErrorResponse errorResponse = ErrorResponse.of(e.getExceptionCode());
+        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(errorResponse.getStatus()));
+    }
+
+    // Exception Error : 위 외의 모든 예외 처리
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("handleEntityNotFoundException", e);
+        final ErrorResponse errorResponse = ErrorResponse.of(ExceptionCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/server/src/main/java/com/codestates/preproject/domain/member/entity/Member.java
+++ b/server/src/main/java/com/codestates/preproject/domain/member/entity/Member.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import javax.validation.constraints.Email;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/server/src/main/java/com/codestates/preproject/exception/BusinessLogicException.java
+++ b/server/src/main/java/com/codestates/preproject/exception/BusinessLogicException.java
@@ -1,0 +1,13 @@
+package com.codestates.preproject.exception;
+
+import lombok.Getter;
+
+public class BusinessLogicException extends RuntimeException {
+    @Getter
+    private ExceptionCode exceptionCode;
+
+    public BusinessLogicException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+    }
+}

--- a/server/src/main/java/com/codestates/preproject/exception/ExceptionCode.java
+++ b/server/src/main/java/com/codestates/preproject/exception/ExceptionCode.java
@@ -1,0 +1,24 @@
+package com.codestates.preproject.exception;
+
+import lombok.Getter;
+
+public enum ExceptionCode {
+    // Member 관련
+    MEMBER_NOT_FOUND(404, "MEMBER NOT FOUND"),
+    MEMBER_EXISTS(409, "MEMBER_EXISTS"),
+    METHOD_NOT_ALLOWED(405, "METHOD NOT ALLOWED"),
+    HANDLE_ACCESS_DENIED(403,"HANDLE ACCESS DENIED"),
+    INVALID_INPUT_VALUE(400,  "INVALID INPUT VALUE"),
+    INTERNAL_SERVER_ERROR(500,"INTERNAL SERVER ERROR");
+
+    @Getter
+    private int status;
+
+    @Getter
+    private String message;
+
+    ExceptionCode(int code, String message) {
+        this.status = code;
+        this.message = message;
+    }
+}

--- a/server/src/main/java/com/codestates/preproject/response/ErrorResponse.java
+++ b/server/src/main/java/com/codestates/preproject/response/ErrorResponse.java
@@ -1,0 +1,95 @@
+package com.codestates.preproject.response;
+
+import com.codestates.preproject.exception.ExceptionCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+
+import javax.validation.ConstraintViolation;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+public class ErrorResponse {
+    private int status;
+    private String message;
+    private List<FieldError> fieldErrors;
+    private List<ConstraintViolationError> violationErrors;
+
+    private ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    private ErrorResponse(final List<FieldError> fieldErrors,
+                          final List<ConstraintViolationError> violationErrors) {
+        this.fieldErrors = fieldErrors;
+        this.violationErrors = violationErrors;
+    }
+
+    public static ErrorResponse of(BindingResult bindingResult) {
+        return new ErrorResponse(FieldError.of(bindingResult), null);
+    }
+
+    public static ErrorResponse of(Set<ConstraintViolation<?>> violations) {
+        return new ErrorResponse(null, ConstraintViolationError.of(violations));
+    }
+
+    public static ErrorResponse of(ExceptionCode exceptionCode) {
+        return new ErrorResponse(exceptionCode.getStatus(), exceptionCode.getMessage());
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus) {
+        return new ErrorResponse(httpStatus.value(), httpStatus.getReasonPhrase());
+    }
+
+    @Getter
+    public static class FieldError {
+        private String field;
+        private Object rejectedValue;
+        private String reason;
+
+        private FieldError(String field, Object rejectedValue, String reason) {
+            this.field = field;
+            this.rejectedValue = rejectedValue;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors =
+                    bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ?
+                                    "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Getter
+    public static class ConstraintViolationError {
+        private String propertyPath;
+        private Object rejectedValue;
+        private String reason;
+
+        private ConstraintViolationError(String propertyPath, Object rejectedValue,
+                                         String reason) {
+            this.propertyPath = propertyPath;
+            this.rejectedValue = rejectedValue;
+            this.reason = reason;
+        }
+
+        public static List<ConstraintViolationError> of(
+                Set<ConstraintViolation<?>> constraintViolations) {
+            return constraintViolations.stream()
+                    .map(constraintViolation -> new ConstraintViolationError(
+                            constraintViolation.getPropertyPath().toString(),
+                            constraintViolation.getInvalidValue().toString(),
+                            constraintViolation.getMessage()
+                    )).collect(Collectors.toList());
+        }
+    }
+}


### PR DESCRIPTION
GlobalExceptionAdvice
유효성 검사에 대한 예외처리
- MethodArgumentNotValidException
- ConstraintViolationException
- BindException

메서드 매개변수 타입 불일치에 대한 예외처리
- MethodArgumentTypeMismatchException

지원하지 않는 HTTP Request 오류에 대한 예외 처리
- HttpRequestMethodNotSupportedException

인가 거부에 대한 예외 처리
- AccessDeniedException

비즈니스 로직에 등록된 오류 예외 처리
- BusinessLogicException

그 외 오류에 대한 예외 처리
- Exception